### PR TITLE
feat: add TypeScript learning program (Junior → SemiSenior)

### DIFF
--- a/learning-program/README.md
+++ b/learning-program/README.md
@@ -1,0 +1,108 @@
+# Programa de práctica: Junior -> SemiSenior (Web + Angular + TypeScript)
+
+Este programa está diseñado para practicar exactamente los ejes que pediste, con foco en:
+
+- Algoritmos y complejidad.
+- TypeScript avanzado con `strict`.
+- Consumo HTTP robusto con mapeo de DTOs.
+- Arquitectura y progreso por competencias.
+- Hábito de calidad con tests automáticos.
+
+## 1) Cómo ejecutar
+
+```bash
+cd learning-program
+npm install
+npm run start
+npm run test
+```
+
+## 2) Estructura didáctica
+
+- `src/algorithms.ts`: prácticas de `Map`, `Set`, `reduce`, y comparación O(n²) vs O(n).
+- `src/typescript-design.ts`: `interface`, `type`, `enum`, `readonly`, opcionales, genéricos y type guards.
+- `src/http-simulation.ts`: DTO -> modelo, timeout, retry y manejo de error centralizado.
+- `src/progress-tracker.ts`: seguimiento por competencia y siguientes temas recomendados.
+- `tests/program.test.js`: validación automática de piezas críticas.
+
+> Todas las funciones del programa tienen comentarios para explicar su objetivo técnico.
+
+## 3) Ruta sugerida por bloques (8 semanas)
+
+### Semana 1-2: Algoritmos y estructuras
+
+- Resolver retos en `src/algorithms.ts`.
+- Medir mentalmente complejidad de cada solución.
+- Objetivo: detectar cuándo una solución pasa de O(n²) a O(n).
+
+### Semana 3-4: TypeScript como diseño
+
+- Evitar `any`.
+- Crear nuevos contratos (`interfaces` y `types`) para features ficticias.
+- Implementar nuevos type guards.
+
+### Semana 5: HTTP/API resiliente
+
+- Extender `fetchShipmentModels` con códigos de error más detallados.
+- Simular escenarios: timeout, backend caído, payload inválido.
+
+### Semana 6: Angular + RxJS (práctica guiada)
+
+Aplicar estos conceptos en tu proyecto Angular real:
+
+- `OnPush`, smart/dumb components.
+- Evitar lógica pesada en template.
+- Reemplazar `subscribe` manual por `async pipe` donde aplique.
+- Usar `switchMap` en flujos dependientes de inputs.
+
+### Semana 7: Testing y calidad
+
+- Agregar tests para cada bug que encuentres.
+- Crear mocks/spies en servicios Angular.
+- Ver cobertura como indicador, no meta final.
+
+### Semana 8: Flujo de equipo y liderazgo técnico
+
+- Practicar commits semánticos (`feat:`, `fix:`, `refactor:`).
+- Escribir PRs con contexto técnico y riesgos.
+- Explicar decisiones de arquitectura en 4-6 bullets.
+
+## 4) Checklist de dominio (autoevaluación)
+
+### Algoritmos (MEDIO)
+- [ ] Identifico O(n) vs O(n²).
+- [ ] Elijo `Map` / `Set` por necesidad real.
+- [ ] Uso `map/filter/reduce` con claridad.
+
+### TypeScript (ALTO)
+- [ ] `strict` activado.
+- [ ] Casi cero `any`.
+- [ ] Uso genéricos y guards en código productivo.
+
+### Git (ALTO)
+- [ ] Distingo `rebase` vs `merge` y cuándo usar cada uno.
+- [ ] Resuelvo conflictos sin romper historia.
+- [ ] Escribo commits semánticos y PRs claras.
+
+### HTTP/APIs (ALTO)
+- [ ] Manejo errores de forma centralizada.
+- [ ] Implemento timeout/retry según caso.
+- [ ] Uso DTOs y mappers.
+
+### Angular Core (ALTO)
+- [ ] Uso `OnPush` y detecto anti-patrones de template.
+- [ ] Diseño smart/dumb components.
+- [ ] Conozco guards/resolvers/lazy loading/signals.
+
+### RxJS (MEDIO-ALTO)
+- [ ] Elijo operador correcto (`switchMap`, `mergeMap`, `combineLatest`).
+- [ ] Evito memory leaks (unsubscribe patterns / async pipe).
+
+### Testing (ALTO)
+- [ ] Tengo unit tests para servicios/componentes críticos.
+- [ ] Sé mockear dependencias.
+
+### Arquitectura y soft skills
+- [ ] Pienso por dominio, no solo por pantalla.
+- [ ] Argumento decisiones técnicas con trade-offs.
+- [ ] Comunico bloqueos y propongo opciones.

--- a/learning-program/dist/algorithms.js
+++ b/learning-program/dist/algorithms.js
@@ -1,0 +1,83 @@
+"use strict";
+/**
+ * Este módulo concentra ejercicios de algoritmos para practicar complejidad y estructuras de datos.
+ */
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.groupShipmentsByCustomer = groupShipmentsByCustomer;
+exports.uniqueRouteCities = uniqueRouteCities;
+exports.piecesByStatus = piecesByStatus;
+exports.countDuplicateRoutesQuadratic = countDuplicateRoutesQuadratic;
+exports.countDuplicateRoutesLinear = countDuplicateRoutesLinear;
+/**
+ * Agrupa envíos por cliente usando Map para tener búsquedas O(1) promedio por clave.
+ */
+function groupShipmentsByCustomer(shipments) {
+    const grouped = new Map();
+    for (const shipment of shipments) {
+        const bucket = grouped.get(shipment.customerId) ?? [];
+        bucket.push(shipment);
+        grouped.set(shipment.customerId, bucket);
+    }
+    return grouped;
+}
+/**
+ * Elimina ciudades duplicadas usando Set y luego ordena alfabéticamente.
+ */
+function uniqueRouteCities(shipments) {
+    const citySet = new Set();
+    shipments.forEach((shipment) => {
+        citySet.add(shipment.origin);
+        citySet.add(shipment.destination);
+    });
+    return [...citySet].sort((a, b) => a.localeCompare(b));
+}
+/**
+ * Resume piezas por estado usando reduce para practicar transformaciones funcionales.
+ */
+function piecesByStatus(shipments) {
+    return shipments.reduce((acc, shipment) => {
+        acc[shipment.status] += shipment.pieces;
+        return acc;
+    }, { pending: 0, in_transit: 0, delivered: 0 });
+}
+/**
+ * Detecta potencial O(n²): busca rutas repetidas comparando cada envío contra todos.
+ * Se deja como ejemplo educativo para luego optimizarlo.
+ */
+function countDuplicateRoutesQuadratic(shipments) {
+    let duplicates = 0;
+    for (let i = 0; i < shipments.length; i += 1) {
+        const current = shipments[i];
+        if (!current) {
+            continue;
+        }
+        for (let j = i + 1; j < shipments.length; j += 1) {
+            const candidate = shipments[j];
+            if (!candidate) {
+                continue;
+            }
+            const sameRoute = current.origin === candidate.origin &&
+                current.destination === candidate.destination;
+            if (sameRoute) {
+                duplicates += 1;
+            }
+        }
+    }
+    return duplicates;
+}
+/**
+ * Versión optimizada O(n): usa un Set de rutas para detectar duplicados en un solo recorrido.
+ */
+function countDuplicateRoutesLinear(shipments) {
+    const seenRoutes = new Set();
+    let duplicates = 0;
+    for (const shipment of shipments) {
+        const key = `${shipment.origin}->${shipment.destination}`;
+        if (seenRoutes.has(key)) {
+            duplicates += 1;
+            continue;
+        }
+        seenRoutes.add(key);
+    }
+    return duplicates;
+}

--- a/learning-program/dist/http-simulation.js
+++ b/learning-program/dist/http-simulation.js
@@ -1,0 +1,61 @@
+"use strict";
+/**
+ * Simulación de consumo HTTP robusto con DTO, mapping, retry y timeout.
+ */
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.mapShipmentDto = mapShipmentDto;
+exports.withTimeout = withTimeout;
+exports.retry = retry;
+exports.fetchShipmentModels = fetchShipmentModels;
+/**
+ * Mapper DTO -> Modelo de dominio para desacoplar frontend de backend.
+ */
+function mapShipmentDto(dto) {
+    return {
+        id: dto.id,
+        customerId: dto.customer_id,
+        origin: dto.city_origin,
+        destination: dto.city_destination,
+        pieces: dto.pieces
+    };
+}
+/**
+ * Ejecuta una promesa con timeout para no dejar requests colgadas.
+ */
+async function withTimeout(promise, timeoutMs) {
+    const timeoutPromise = new Promise((_, reject) => {
+        setTimeout(() => reject(new Error(`Timeout de ${timeoutMs}ms excedido`)), timeoutMs);
+    });
+    return Promise.race([promise, timeoutPromise]);
+}
+/**
+ * Reintenta una operación asíncrona para simular resiliencia de red.
+ */
+async function retry(operation, retries = 2) {
+    let latestError;
+    for (let attempt = 0; attempt <= retries; attempt += 1) {
+        try {
+            return await operation();
+        }
+        catch (error) {
+            latestError = error;
+        }
+    }
+    throw latestError;
+}
+/**
+ * Caso de uso completo: llama API simulada, aplica timeout, retry y mapping tipado.
+ */
+async function fetchShipmentModels(loadDtos) {
+    try {
+        const dtos = await retry(() => withTimeout(loadDtos(), 1200), 2);
+        return { ok: true, data: dtos.map(mapShipmentDto) };
+    }
+    catch (error) {
+        return {
+            ok: false,
+            errorMessage: error instanceof Error ? error.message : "Error desconocido",
+            statusCode: 503
+        };
+    }
+}

--- a/learning-program/dist/index.js
+++ b/learning-program/dist/index.js
@@ -1,0 +1,53 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const algorithms_1 = require("./algorithms");
+const http_simulation_1 = require("./http-simulation");
+const progress_tracker_1 = require("./progress-tracker");
+const typescript_design_1 = require("./typescript-design");
+/**
+ * Punto de entrada del programa de práctica.
+ * Ejecuta mini retos y muestra resultados esperados para autoevaluación.
+ */
+async function main() {
+    const shipments = [
+        { id: "S1", customerId: "C1", origin: "Bogotá", destination: "Medellín", pieces: 3, status: "pending" },
+        { id: "S2", customerId: "C1", origin: "Bogotá", destination: "Cali", pieces: 4, status: "in_transit" },
+        { id: "S3", customerId: "C2", origin: "Bogotá", destination: "Medellín", pieces: 2, status: "delivered" }
+    ];
+    console.log("\n=== Algoritmos ===");
+    console.log("Clientes agrupados:", (0, algorithms_1.groupShipmentsByCustomer)(shipments));
+    console.log("Ciudades únicas:", (0, algorithms_1.uniqueRouteCities)(shipments));
+    console.log("Piezas por estado:", (0, algorithms_1.piecesByStatus)(shipments));
+    console.log("Duplicados O(n²):", (0, algorithms_1.countDuplicateRoutesQuadratic)(shipments));
+    console.log("Duplicados O(n):", (0, algorithms_1.countDuplicateRoutesLinear)(shipments));
+    console.log("\n=== TypeScript diseño ===");
+    const task = (0, typescript_design_1.createTask)({ id: "T1", title: "Practicar switchMap", priority: typescript_design_1.Priority.High });
+    console.log("Tarea inicial:", task);
+    console.log("Tarea completada:", (0, typescript_design_1.completeTask)(task));
+    console.log("\n=== HTTP robusto (simulado) ===");
+    const apiResult = await (0, http_simulation_1.fetchShipmentModels)(async () => [
+        {
+            id: "S-100",
+            customer_id: "C-500",
+            city_origin: "Quito",
+            city_destination: "Cuenca",
+            pieces: 5
+        }
+    ]);
+    console.log("Resultado API:", apiResult);
+    console.log("\n=== Progreso de competencias ===");
+    const competency = {
+        id: "angular-core",
+        name: "Angular Core Framework",
+        target: "alto",
+        requiredTopics: ["lifecycle", "onpush", "smart-dumb", "signals", "lazy-loading"]
+    };
+    const entry = { competencyId: "angular-core", completedTopics: ["lifecycle", "onpush"] };
+    const progress = (0, progress_tracker_1.calculateProgress)(competency, entry);
+    console.log("Progreso %:", progress);
+    console.log("Nivel inferido:", (0, progress_tracker_1.inferLevel)(progress));
+    console.log("Siguientes tópicos:", (0, progress_tracker_1.nextTopics)(competency, entry));
+}
+main().catch((error) => {
+    console.error("Error ejecutando el programa:", error);
+});

--- a/learning-program/dist/progress-tracker.js
+++ b/learning-program/dist/progress-tracker.js
@@ -1,0 +1,33 @@
+"use strict";
+/**
+ * Motor simple de progreso para medir el avance por competencia semiSenior.
+ */
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.calculateProgress = calculateProgress;
+exports.inferLevel = inferLevel;
+exports.nextTopics = nextTopics;
+/**
+ * Calcula porcentaje de avance de una competencia en base a tópicos completados.
+ */
+function calculateProgress(competency, entry) {
+    const required = competency.requiredTopics.length;
+    if (required === 0) {
+        return 100;
+    }
+    const completedSet = new Set(entry.completedTopics);
+    const completedCount = competency.requiredTopics.filter((topic) => completedSet.has(topic)).length;
+    return Math.round((completedCount / required) * 100);
+}
+/**
+ * Clasifica nivel actual aproximado por porcentaje para dar feedback rápido.
+ */
+function inferLevel(progressPercent) {
+    return progressPercent >= 70 ? "semiSenior" : "junior";
+}
+/**
+ * Construye un plan de siguiente paso usando filter/map para priorizar pendientes.
+ */
+function nextTopics(competency, entry, max = 3) {
+    const done = new Set(entry.completedTopics);
+    return competency.requiredTopics.filter((topic) => !done.has(topic)).slice(0, max);
+}

--- a/learning-program/dist/typescript-design.js
+++ b/learning-program/dist/typescript-design.js
@@ -1,0 +1,36 @@
+"use strict";
+/**
+ * Este módulo demuestra cómo usar TypeScript como herramienta de diseño.
+ */
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.Priority = void 0;
+exports.createTask = createTask;
+exports.isSuccessResult = isSuccessResult;
+exports.completeTask = completeTask;
+var Priority;
+(function (Priority) {
+    Priority["Low"] = "LOW";
+    Priority["Medium"] = "MEDIUM";
+    Priority["High"] = "HIGH";
+})(Priority || (exports.Priority = Priority = {}));
+/**
+ * Crea una tarea de aprendizaje con defaults para evitar datos incompletos.
+ */
+function createTask(input) {
+    return {
+        ...input,
+        completed: false
+    };
+}
+/**
+ * Aplica un type guard para hacer narrowing y manejar errores en compilación.
+ */
+function isSuccessResult(result) {
+    return result.ok;
+}
+/**
+ * Función utilitaria para completar tareas y retornar nuevo estado inmutable.
+ */
+function completeTask(task) {
+    return { ...task, completed: true };
+}

--- a/learning-program/package.json
+++ b/learning-program/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "semisenior-learning-program",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Programa de práctica para evolucionar de desarrollador web junior a semiSenior.",
+  "type": "commonjs",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "start": "npm run build && node dist/index.js",
+    "test": "npm run build && node --test tests/**/*.test.js"
+  }
+}

--- a/learning-program/src/algorithms.ts
+++ b/learning-program/src/algorithms.ts
@@ -1,0 +1,105 @@
+/**
+ * Este módulo concentra ejercicios de algoritmos para practicar complejidad y estructuras de datos.
+ */
+
+export interface Shipment {
+  readonly id: string;
+  readonly customerId: string;
+  readonly origin: string;
+  readonly destination: string;
+  readonly pieces: number;
+  readonly status: "pending" | "in_transit" | "delivered";
+}
+
+/**
+ * Agrupa envíos por cliente usando Map para tener búsquedas O(1) promedio por clave.
+ */
+export function groupShipmentsByCustomer(shipments: readonly Shipment[]): Map<string, Shipment[]> {
+  const grouped = new Map<string, Shipment[]>();
+
+  for (const shipment of shipments) {
+    const bucket = grouped.get(shipment.customerId) ?? [];
+    bucket.push(shipment);
+    grouped.set(shipment.customerId, bucket);
+  }
+
+  return grouped;
+}
+
+/**
+ * Elimina ciudades duplicadas usando Set y luego ordena alfabéticamente.
+ */
+export function uniqueRouteCities(shipments: readonly Shipment[]): string[] {
+  const citySet = new Set<string>();
+
+  shipments.forEach((shipment) => {
+    citySet.add(shipment.origin);
+    citySet.add(shipment.destination);
+  });
+
+  return [...citySet].sort((a, b) => a.localeCompare(b));
+}
+
+/**
+ * Resume piezas por estado usando reduce para practicar transformaciones funcionales.
+ */
+export function piecesByStatus(shipments: readonly Shipment[]): Record<Shipment["status"], number> {
+  return shipments.reduce<Record<Shipment["status"], number>>(
+    (acc, shipment) => {
+      acc[shipment.status] += shipment.pieces;
+      return acc;
+    },
+    { pending: 0, in_transit: 0, delivered: 0 }
+  );
+}
+
+/**
+ * Detecta potencial O(n²): busca rutas repetidas comparando cada envío contra todos.
+ * Se deja como ejemplo educativo para luego optimizarlo.
+ */
+export function countDuplicateRoutesQuadratic(shipments: readonly Shipment[]): number {
+  let duplicates = 0;
+
+  for (let i = 0; i < shipments.length; i += 1) {
+    const current = shipments[i];
+    if (!current) {
+      continue;
+    }
+
+    for (let j = i + 1; j < shipments.length; j += 1) {
+      const candidate = shipments[j];
+      if (!candidate) {
+        continue;
+      }
+
+      const sameRoute =
+        current.origin === candidate.origin &&
+        current.destination === candidate.destination;
+
+      if (sameRoute) {
+        duplicates += 1;
+      }
+    }
+  }
+
+  return duplicates;
+}
+
+/**
+ * Versión optimizada O(n): usa un Set de rutas para detectar duplicados en un solo recorrido.
+ */
+export function countDuplicateRoutesLinear(shipments: readonly Shipment[]): number {
+  const seenRoutes = new Set<string>();
+  let duplicates = 0;
+
+  for (const shipment of shipments) {
+    const key = `${shipment.origin}->${shipment.destination}`;
+    if (seenRoutes.has(key)) {
+      duplicates += 1;
+      continue;
+    }
+    seenRoutes.add(key);
+  }
+
+  return duplicates;
+}

--- a/learning-program/src/http-simulation.ts
+++ b/learning-program/src/http-simulation.ts
@@ -1,0 +1,80 @@
+/**
+ * Simulación de consumo HTTP robusto con DTO, mapping, retry y timeout.
+ */
+
+import { ApiResult } from "./typescript-design";
+
+export interface ShipmentDto {
+  id: string;
+  customer_id: string;
+  city_origin: string;
+  city_destination: string;
+  pieces: number;
+}
+
+export interface ShipmentModel {
+  readonly id: string;
+  readonly customerId: string;
+  readonly origin: string;
+  readonly destination: string;
+  readonly pieces: number;
+}
+
+/**
+ * Mapper DTO -> Modelo de dominio para desacoplar frontend de backend.
+ */
+export function mapShipmentDto(dto: ShipmentDto): ShipmentModel {
+  return {
+    id: dto.id,
+    customerId: dto.customer_id,
+    origin: dto.city_origin,
+    destination: dto.city_destination,
+    pieces: dto.pieces
+  };
+}
+
+/**
+ * Ejecuta una promesa con timeout para no dejar requests colgadas.
+ */
+export async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    setTimeout(() => reject(new Error(`Timeout de ${timeoutMs}ms excedido`)), timeoutMs);
+  });
+
+  return Promise.race([promise, timeoutPromise]);
+}
+
+/**
+ * Reintenta una operación asíncrona para simular resiliencia de red.
+ */
+export async function retry<T>(operation: () => Promise<T>, retries = 2): Promise<T> {
+  let latestError: unknown;
+
+  for (let attempt = 0; attempt <= retries; attempt += 1) {
+    try {
+      return await operation();
+    } catch (error) {
+      latestError = error;
+    }
+  }
+
+  throw latestError;
+}
+
+/**
+ * Caso de uso completo: llama API simulada, aplica timeout, retry y mapping tipado.
+ */
+export async function fetchShipmentModels(
+  loadDtos: () => Promise<ShipmentDto[]>
+): Promise<ApiResult<ShipmentModel[]>> {
+  try {
+    const dtos = await retry(() => withTimeout(loadDtos(), 1200), 2);
+    return { ok: true, data: dtos.map(mapShipmentDto) };
+  } catch (error) {
+    return {
+      ok: false,
+      errorMessage: error instanceof Error ? error.message : "Error desconocido",
+      statusCode: 503
+    };
+  }
+}

--- a/learning-program/src/index.ts
+++ b/learning-program/src/index.ts
@@ -1,0 +1,65 @@
+import {
+  countDuplicateRoutesLinear,
+  countDuplicateRoutesQuadratic,
+  groupShipmentsByCustomer,
+  piecesByStatus,
+  uniqueRouteCities,
+  type Shipment
+} from "./algorithms";
+import { fetchShipmentModels } from "./http-simulation";
+import { calculateProgress, inferLevel, nextTopics, type Competency } from "./progress-tracker";
+import { Priority, completeTask, createTask } from "./typescript-design";
+
+/**
+ * Punto de entrada del programa de práctica.
+ * Ejecuta mini retos y muestra resultados esperados para autoevaluación.
+ */
+async function main(): Promise<void> {
+  const shipments: Shipment[] = [
+    { id: "S1", customerId: "C1", origin: "Bogotá", destination: "Medellín", pieces: 3, status: "pending" },
+    { id: "S2", customerId: "C1", origin: "Bogotá", destination: "Cali", pieces: 4, status: "in_transit" },
+    { id: "S3", customerId: "C2", origin: "Bogotá", destination: "Medellín", pieces: 2, status: "delivered" }
+  ];
+
+  console.log("\n=== Algoritmos ===");
+  console.log("Clientes agrupados:", groupShipmentsByCustomer(shipments));
+  console.log("Ciudades únicas:", uniqueRouteCities(shipments));
+  console.log("Piezas por estado:", piecesByStatus(shipments));
+  console.log("Duplicados O(n²):", countDuplicateRoutesQuadratic(shipments));
+  console.log("Duplicados O(n):", countDuplicateRoutesLinear(shipments));
+
+  console.log("\n=== TypeScript diseño ===");
+  const task = createTask({ id: "T1", title: "Practicar switchMap", priority: Priority.High });
+  console.log("Tarea inicial:", task);
+  console.log("Tarea completada:", completeTask(task));
+
+  console.log("\n=== HTTP robusto (simulado) ===");
+  const apiResult = await fetchShipmentModels(async () => [
+    {
+      id: "S-100",
+      customer_id: "C-500",
+      city_origin: "Quito",
+      city_destination: "Cuenca",
+      pieces: 5
+    }
+  ]);
+  console.log("Resultado API:", apiResult);
+
+  console.log("\n=== Progreso de competencias ===");
+  const competency: Competency = {
+    id: "angular-core",
+    name: "Angular Core Framework",
+    target: "alto",
+    requiredTopics: ["lifecycle", "onpush", "smart-dumb", "signals", "lazy-loading"]
+  };
+  const entry = { competencyId: "angular-core", completedTopics: ["lifecycle", "onpush"] };
+  const progress = calculateProgress(competency, entry);
+
+  console.log("Progreso %:", progress);
+  console.log("Nivel inferido:", inferLevel(progress));
+  console.log("Siguientes tópicos:", nextTopics(competency, entry));
+}
+
+main().catch((error) => {
+  console.error("Error ejecutando el programa:", error);
+});

--- a/learning-program/src/progress-tracker.ts
+++ b/learning-program/src/progress-tracker.ts
@@ -1,0 +1,47 @@
+/**
+ * Motor simple de progreso para medir el avance por competencia semiSenior.
+ */
+
+export type SkillLevel = "junior" | "semiSenior";
+
+export interface Competency {
+  readonly id: string;
+  readonly name: string;
+  readonly target: "medio" | "medio-alto" | "alto";
+  readonly requiredTopics: readonly string[];
+}
+
+export interface ProgressEntry {
+  readonly competencyId: string;
+  readonly completedTopics: readonly string[];
+}
+
+/**
+ * Calcula porcentaje de avance de una competencia en base a tópicos completados.
+ */
+export function calculateProgress(competency: Competency, entry: ProgressEntry): number {
+  const required = competency.requiredTopics.length;
+  if (required === 0) {
+    return 100;
+  }
+
+  const completedSet = new Set(entry.completedTopics);
+  const completedCount = competency.requiredTopics.filter((topic) => completedSet.has(topic)).length;
+
+  return Math.round((completedCount / required) * 100);
+}
+
+/**
+ * Clasifica nivel actual aproximado por porcentaje para dar feedback rápido.
+ */
+export function inferLevel(progressPercent: number): SkillLevel {
+  return progressPercent >= 70 ? "semiSenior" : "junior";
+}
+
+/**
+ * Construye un plan de siguiente paso usando filter/map para priorizar pendientes.
+ */
+export function nextTopics(competency: Competency, entry: ProgressEntry, max = 3): string[] {
+  const done = new Set(entry.completedTopics);
+  return competency.requiredTopics.filter((topic) => !done.has(topic)).slice(0, max);
+}

--- a/learning-program/src/typescript-design.ts
+++ b/learning-program/src/typescript-design.ts
@@ -1,0 +1,55 @@
+/**
+ * Este módulo demuestra cómo usar TypeScript como herramienta de diseño.
+ */
+
+export enum Priority {
+  Low = "LOW",
+  Medium = "MEDIUM",
+  High = "HIGH"
+}
+
+export interface LearningTask {
+  readonly id: string;
+  title: string;
+  priority: Priority;
+  completed: boolean;
+  optionalNotes?: string;
+}
+
+export type ApiResult<T> =
+  | { ok: true; data: T }
+  | { ok: false; errorMessage: string; statusCode: number };
+
+/**
+ * Crea una tarea de aprendizaje con defaults para evitar datos incompletos.
+ */
+export function createTask(input: Omit<LearningTask, "completed">): LearningTask {
+  return {
+    ...input,
+    completed: false
+  };
+}
+
+/**
+ * Generic reutilizable para paginar cualquier tipo de dato.
+ */
+export interface Paginated<T> {
+  readonly page: number;
+  readonly pageSize: number;
+  readonly total: number;
+  readonly rows: readonly T[];
+}
+
+/**
+ * Aplica un type guard para hacer narrowing y manejar errores en compilación.
+ */
+export function isSuccessResult<T>(result: ApiResult<T>): result is { ok: true; data: T } {
+  return result.ok;
+}
+
+/**
+ * Función utilitaria para completar tareas y retornar nuevo estado inmutable.
+ */
+export function completeTask(task: LearningTask): LearningTask {
+  return { ...task, completed: true };
+}

--- a/learning-program/tests/program.test.js
+++ b/learning-program/tests/program.test.js
@@ -1,0 +1,53 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { countDuplicateRoutesLinear, countDuplicateRoutesQuadratic, piecesByStatus } = require('../dist/algorithms');
+const { fetchShipmentModels } = require('../dist/http-simulation');
+const { calculateProgress, inferLevel } = require('../dist/progress-tracker');
+
+test('algoritmos de duplicados lineal y cuadrático entregan resultado consistente', () => {
+  const data = [
+    { id: '1', customerId: 'A', origin: 'Bogotá', destination: 'Cali', pieces: 1, status: 'pending' },
+    { id: '2', customerId: 'B', origin: 'Bogotá', destination: 'Cali', pieces: 2, status: 'delivered' },
+    { id: '3', customerId: 'C', origin: 'Bogotá', destination: 'Medellín', pieces: 1, status: 'in_transit' }
+  ];
+
+  assert.equal(countDuplicateRoutesQuadratic(data), 1);
+  assert.equal(countDuplicateRoutesLinear(data), 1);
+  assert.deepEqual(piecesByStatus(data), { pending: 1, in_transit: 1, delivered: 2 });
+});
+
+test('fetchShipmentModels mapea correctamente DTO a modelo', async () => {
+  const result = await fetchShipmentModels(async () => [
+    {
+      id: 'S1',
+      customer_id: 'C1',
+      city_origin: 'Lima',
+      city_destination: 'Arequipa',
+      pieces: 10
+    }
+  ]);
+
+  assert.equal(result.ok, true);
+  if (result.ok) {
+    assert.equal(result.data[0]?.customerId, 'C1');
+  }
+});
+
+test('tracker de progreso clasifica junior/semiSenior', () => {
+  const competency = {
+    id: 'ts',
+    name: 'TypeScript',
+    target: 'alto',
+    requiredTopics: ['generics', 'guards', 'strict', 'readonly']
+  };
+
+  const low = calculateProgress(competency, { competencyId: 'ts', completedTopics: ['generics'] });
+  const high = calculateProgress(competency, {
+    competencyId: 'ts',
+    completedTopics: ['generics', 'guards', 'strict']
+  });
+
+  assert.equal(inferLevel(low), 'junior');
+  assert.equal(inferLevel(high), 'semiSenior');
+});

--- a/learning-program/tsconfig.json
+++ b/learning-program/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
### Motivation
- Proveer un programa práctico en TypeScript que guíe la evolución de desarrollador web de "junior" a "semiSenior" cubriendo algoritmos, diseño de tipos, consumo HTTP resiliente, reactividad y calidad de código.
- Entregar ejercicios y utilidades con comentarios por función para que cada pieza sirva como material de aprendizaje y referencia técnica.

### Description
- Se agregó el directorio `learning-program/` con `src/` (módulos), `tests/`, `package.json`, `tsconfig.json` (modo `strict`) y `README.md` con una ruta de estudio de 8 semanas y checklist de autoevaluación. 
- Implementados módulos clave: `src/algorithms.ts` (`Map`, `Set`, `reduce`, O(n²) vs O(n)), `src/typescript-design.ts` (interfaces, enums, genéricos, guards), `src/http-simulation.ts` (DTO→modelo, `withTimeout`, `retry`), `src/progress-tracker.ts` (cálculo de progreso y sugerencia de siguientes tópicos) y `src/index.ts` (punto de entrada demostrativo); todas las funciones incluyen comentarios explicativos. 
- Se añadieron pruebas (`tests/program.test.js`) y scripts en `package.json` (`build`, `start`, `test`), además de artefactos compilados en `dist/`; se aplicaron pequeñas correcciones TypeScript para compilar (`guard` en comparación cuadrática y eliminación de `process.exitCode`).

### Testing
- `npm install` dentro de `learning-program/` falló en este entorno por restricciones del registry (`403 Forbidden`).
- `npm run build` (dentro de `learning-program/`) se ejecutó correctamente y generó `dist/` sin errores. 
- `npm run test` se ejecutó y pasó todos los tests automatizados (`3` tests OK, `0` fallos). 
- `npm run start` se ejecutó y mostró la salida demo esperada del programa (ejemplos de algoritmos, mapping HTTP y tracking de progreso).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cbebb667c8329a0a36c0fbdffb121)